### PR TITLE
Add Aarch64 SIMD support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ simd = [] # Enable explicit SIMD optimizations on supported platforms.
 proptest = "1.0"
 criterion = { version = "0.3", features = ["html_reports"] }
 
+[profile.release]
+lto = "thin"
+
 #-----------------------------------------
 
 [[bench]]

--- a/src/lines_crlf.rs
+++ b/src/lines_crlf.rs
@@ -148,6 +148,7 @@ fn to_byte_idx_impl<T: ByteChunk>(text: &[u8], line_idx: usize) -> usize {
 ///
 /// The following unicode sequences are considered newlines by this function:
 /// - u{000A}        (Line Feed)
+/// - u{000D}        (Carriage Return)
 #[inline(always)]
 fn count_breaks_impl<T: ByteChunk>(text: &[u8]) -> usize {
     // Get `middle` so we can do more efficient chunk-based counting.


### PR DESCRIPTION
closes #10 

I finally found out what the issue was with the benchmarks. For some reason adding the `#[inline]` annotation to the public functions was causing a massive slowdown on the benchmarks. I don't know if this is criterion issue or a rust issue. I opened an issue over at criterion, but I think it will be a while before they get to it.

https://github.com/bheisler/criterion.rs/issues/649

# performance
However most of these functions are probably not great inline candidates anyways, because they tend to be pretty heavy. But in this PR I have removed the annotations.

Overall I am pretty happy with the initial results. There are [87 performance improvements and 14 regressions](https://gist.github.com/CeleritasCelery/0db39993319781b9bc7e759d43a29902).

 I will continue to look at the regressions. One thing that surprised me is that the char_count algorithm was about 10-15% slower on ARM simd. I reworked the algorithm to make it faster using the code below and it improved significantly. 

```rust
        // Take care of the middle bytes in big chunks
        for chunk in middle {
            inv_count += chunk.bitand(T::splat(0xc0)).cmp_eq_byte(0x80).sum_bytes();
        }
```

But this approach made the performance worse on x86 platforms (I think that is because SSE doesn't have a reducing sum instruction). So I did some loop unrolling instead. This will improve x86 as well. All the algorithms would benefit greatly from loop unrolling but we can add that later.