### PR TITLE
Add newlines, large benchmark, and throughput measures to benchmarks

### DIFF
--- a/benches/text/lines.txt
+++ b/benches/text/lines.txt
@@ -1,0 +1,5 @@
+日本 is a West Germanic ー百 that
+出典: spoken in early
+medieval 日本 eventually
+became commons england
+


### PR DESCRIPTION
Added a throughput measurement to the criterion report. This will make it easier to see GB/s for a particular algorithm. I like looking at throughput because you can compare benchmarks regardless of size. 

Also added a large benchmark that will test crossing chunk boundaries. These should be near the maximum throughput.

 Lastly added the following line separators to the benchmarks text:

- Line Feed
- Vertical Tab
- Form Feed
- Carriage Return
- Line Separator
- Next Line
- Paragraph Separator

The benchmark names no longer exactly match their size. I am not sure if this a problem or not. Let me know what you think of the changes.