### PR TITLE
Fix regression when inlining SIMD

### DIFF
--- a/src/byte_chunk.rs
+++ b/src/byte_chunk.rs
@@ -328,6 +328,7 @@ impl ByteChunk for aarch64::uint8x16_t {
         unsafe { aarch64::vandq_u8(*self, other) }
     }
 
+    #[inline(always)]
     fn add(&self, other: Self) -> Self {
         unsafe { aarch64::vaddq_u8(*self, other) }
     }


### PR DESCRIPTION
I reported initially that adding `#[inline]` was making the benchmarks perform 10x worse. We worked around this by enabling LTO, but I got some [help](https://github.com/rust-lang/rust/issues/107617#issuecomment-1422000166) from the rust lang folks and it was simply my error. The comment explains it better, but essentially when inlining it couldn't see this function, so it turned into a function call instead of a single instruction. This prevented other optimization and lead to the performance breakdown I observed.